### PR TITLE
fix: use packet timestamps and raw AnnexB push to fix gop=0

### DIFF
--- a/v5/index.go
+++ b/v5/index.go
@@ -117,9 +117,7 @@ func (j *JT1078Plugin) Start() (err error) {
 			}),
 			pkg.WithEnableIntercom(j.Intercom.Enable),
 			pkg.WithSessions(j.sessions),
-			pkg.WithTimestampFunc(func(_ *jt1078.Packet) time.Duration {
-				return time.Duration(time.Now().UnixMilli()) // 实时视频使用本机时间戳
-			}),
+			pkg.WithTimestampFunc(newPacketTimestamp()),
 			pkg.WithOverTime(time.Duration(tmp.OverTimeSecond)*time.Second),
 			pkg.WithDebug(tmp.Debug.Enable, tmp.Debug.Dir, time.Duration(tmp.Debug.SaveTimeSecond)*time.Second),
 		)
@@ -137,9 +135,7 @@ func (j *JT1078Plugin) Start() (err error) {
 				}, "-")
 				return j.Publish(ctx, streamPath) // 回放唯一
 			}),
-			pkg.WithTimestampFunc(func(pack *jt1078.Packet) time.Duration {
-				return time.Duration(pack.Timestamp) // 录像回放使用设备的
-			}),
+			pkg.WithTimestampFunc(newPacketTimestamp()),
 			pkg.WithOverTime(time.Duration(j.Playback.OverTimeSecond)*time.Second),
 			pkg.WithDebug(tmp.Debug.Enable, tmp.Debug.Dir, time.Duration(tmp.Debug.SaveTimeSecond)*time.Second),
 		)

--- a/v5/pkg/connection.go
+++ b/v5/pkg/connection.go
@@ -189,17 +189,13 @@ func (c *connection) handle(packet *jt1078.Packet) error {
 			c.videoWriter = m7s.NewPublishVideoWriter[*format.AnnexB](c.publisher, allocator)
 		})
 		writer := c.videoWriter
-		// 为每帧创建 H26xFrame
 		frame := writer.VideoFrame
-		// 设置正确间隔的时间戳
 		frame.Timestamp = c.timestampFunc(packet)
-		// 写入 NALU 数据
-		nalus := frame.GetNalus()
-		// 假如 frameData 中只有一个 NALU，否则需要循环执行下面的代码
-		p := nalus.GetNextPointer()
+		// Push raw AnnexB data — do NOT use GetNalus()/PushOne() as that sets
+		// HasRaw()=true and skips Demux(), which is needed to split NALUs and
+		// detect SPS/PPS/IDR for GOP tracking.
 		mem := frame.NextN(len(data))
 		copy(mem, data)
-		p.PushOne(mem)
 		return writer.NextVideo()
 
 	default:

--- a/v5/timestamp.go
+++ b/v5/timestamp.go
@@ -1,0 +1,22 @@
+package v5
+
+import (
+	"time"
+
+	"github.com/cuteLittleDevil/go-jt808/protocol/jt1078"
+)
+
+// newPacketTimestamp returns a timestamp function that uses the JT1078 packet's
+// own Timestamp field (uint64 milliseconds), normalized relative to the first
+// packet. This works for both realtime and playback streams.
+func newPacketTimestamp() func(pack *jt1078.Packet) time.Duration {
+	var baseTS uint64
+	var set bool
+	return func(pack *jt1078.Packet) time.Duration {
+		if !set {
+			baseTS = pack.Timestamp
+			set = true
+		}
+		return time.Duration(pack.Timestamp-baseTS) * time.Millisecond
+	}
+}


### PR DESCRIPTION
I was facing issues similar to those reported in #6 and went down a rabbit-hole to try and resolve it.

In my case, subscribers would get no data and `gop: 0` was reported which was breaking video players from being able to view the stream - I was using a ffmpeg relay to 'correct' the issue, but wanted to simplify my setup and understand why it was an issue. 

### Bug 1: Timestamps produce zero deltas
Currently, the realtime timestamp function uses `time.Duration(time.Now().UnixMilli())`. `time.Now()` returns essentially the same value for each one, so every frame gets an identical timestamp. m7s's `Tame()` normalizer floors them all to `1ms`, producing zero inter-frame deltas. This breaks playback timing in output format (FLV, HLS, etc).

The playback function has a similar issue - `time.Duration(pack.Timestamp)` treats the packet's millisecond timestamp as nanoseconds, making deltas too small for `Tame()` to distinguish.

### Bug 2: AnnexB Demux() is skipped - keyframes never detected
Currently, the video handler calls `GetNalus()`/`PushOne()` which sets `HasRaw()=true`. This tells m7s the NALU's are already parsed and it skips `Demux()`, which is the function that splits AnnexB start codes and identifies IDR/SPS/PPS. Without IDR detection, GOP count stays at 0 and subscribers can never start (they need a keyframe).

### Fix

1. **Timestamps**: Use the JT1078 packet's own `Timestamp` field (which has correct 40ms deltas for 25fps), normalized relative to the first packet. This replaces both the realtime and playback timestamp functions.

2. **AnnexB**: Use `frame.NextN()` + `copy()` instead of `GetNalus()`/`PushOne()`. This leaves `HasRaw()=false` so `Demux()` runs and properly detects keyframes.

### Result

Before: `gop: 0`, no playback possible except JessibucaPRO.
After: `gop: 25, fps: 25, 1280x720`, FLV and HLS work in mpegts.js/VLC/Safari.

**Note:** HLS also needs an `onpub.transform` config - see example config below.
HLS, m7s requires you to tell it which streams to generate segments for

```yaml
hls:
  enable: true
  onpub:
    transform:
      "^live/jt107[89]-.+":
        input: "2s x 5"
        output:
          - {}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timestamp inconsistencies between real-time and playback streaming modes by standardizing timestamp normalization.
  * Optimized video frame handling for H.264/H.265 streams for improved processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->