### PR TITLE
fix: prevent media connection panics after publisher timeout

### DIFF
--- a/v5/pkg/connection.go
+++ b/v5/pkg/connection.go
@@ -18,6 +18,14 @@ import (
 	"time"
 )
 
+var (
+	errPublisherUnavailable   = errors.New("publisher unavailable")
+	errAudioWriterUnavailable = errors.New("audio writer unavailable")
+	errAudioFrameUnavailable  = errors.New("audio frame unavailable")
+	errVideoWriterUnavailable = errors.New("video writer unavailable")
+	errVideoFrameUnavailable  = errors.New("video frame unavailable")
+)
+
 type connection struct {
 	conn net.Conn
 	*slog.Logger
@@ -161,16 +169,49 @@ func (c *connection) stop() {
 	})
 }
 
+func (c *connection) getAudioWriter() (*m7s.PublishAudioWriter[*format.Mpeg2Audio], error) {
+	if c.publisher == nil {
+		return nil, errPublisherUnavailable
+	}
+	c.audioWriterOnce.Do(func() {
+		allocator := gomem.NewScalableMemoryAllocator(1 << gomem.MinPowerOf2)
+		c.audioWriter = m7s.NewPublishAudioWriter[*format.Mpeg2Audio](c.publisher, allocator)
+	})
+	if c.audioWriter == nil {
+		return nil, errAudioWriterUnavailable
+	}
+	if c.audioWriter.AudioFrame == nil {
+		return nil, errAudioFrameUnavailable
+	}
+	return c.audioWriter, nil
+}
+
+func (c *connection) getVideoWriter() (*m7s.PublishVideoWriter[*format.AnnexB], error) {
+	if c.publisher == nil {
+		return nil, errPublisherUnavailable
+	}
+	c.videoWriterOnce.Do(func() {
+		allocator := gomem.NewScalableMemoryAllocator(1 << gomem.MinPowerOf2)
+		c.videoWriter = m7s.NewPublishVideoWriter[*format.AnnexB](c.publisher, allocator)
+	})
+	if c.videoWriter == nil {
+		return nil, errVideoWriterUnavailable
+	}
+	if c.videoWriter.VideoFrame == nil {
+		return nil, errVideoFrameUnavailable
+	}
+	return c.videoWriter, nil
+}
+
 func (c *connection) handle(packet *jt1078.Packet) error {
 	data := packet.Body
 
 	switch pt := packet.Flag.PT; pt {
 	case jt1078.PTAAC, jt1078.PTG711A, jt1078.PTG711U:
-		c.audioWriterOnce.Do(func() {
-			allocator := gomem.NewScalableMemoryAllocator(1 << gomem.MinPowerOf2)
-			c.audioWriter = m7s.NewPublishAudioWriter[*format.Mpeg2Audio](c.publisher, allocator)
-		})
-		writer := c.audioWriter
+		writer, err := c.getAudioWriter()
+		if err != nil {
+			return err
+		}
 		frame := writer.AudioFrame
 		frame.ICodecCtx = &codec.AACCtx{}
 		if pt == jt1078.PTG711A {
@@ -184,11 +225,10 @@ func (c *connection) handle(packet *jt1078.Packet) error {
 		return writer.NextAudio()
 
 	case jt1078.PTH264, jt1078.PTH265:
-		c.videoWriterOnce.Do(func() {
-			allocator := gomem.NewScalableMemoryAllocator(1 << gomem.MinPowerOf2)
-			c.videoWriter = m7s.NewPublishVideoWriter[*format.AnnexB](c.publisher, allocator)
-		})
-		writer := c.videoWriter
+		writer, err := c.getVideoWriter()
+		if err != nil {
+			return err
+		}
 		frame := writer.VideoFrame
 		frame.Timestamp = c.timestampFunc(packet)
 		// Push raw AnnexB data — do NOT use GetNalus()/PushOne() as that sets

--- a/v5/pkg/connection_test.go
+++ b/v5/pkg/connection_test.go
@@ -1,0 +1,128 @@
+package pkg
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cuteLittleDevil/go-jt808/protocol/jt1078"
+	"m7s.live/v5"
+	"m7s.live/v5/pkg/format"
+)
+
+func newTestConnection() *connection {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	return newConnection(nil, logger, func(*jt1078.Packet) time.Duration { return 0 })
+}
+
+func TestConnectionHandleRejectsUnavailablePublisher(t *testing.T) {
+	c := newTestConnection()
+	err := c.handle(&jt1078.Packet{Flag: jt1078.Flag{PT: jt1078.PTH264}})
+	if !errors.Is(err, errPublisherUnavailable) {
+		t.Fatalf("handle() error = %v, want %v", err, errPublisherUnavailable)
+	}
+}
+
+func TestConnectionHandleRejectsUnavailableWriters(t *testing.T) {
+	tests := []struct {
+		name string
+		pt   jt1078.PTType
+		want error
+	}{
+		{name: "audio", pt: jt1078.PTAAC, want: errAudioWriterUnavailable},
+		{name: "video", pt: jt1078.PTH264, want: errVideoWriterUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestConnection()
+			c.publisher = &m7s.Publisher{}
+			err := c.handle(&jt1078.Packet{Flag: jt1078.Flag{PT: tt.pt}})
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("handle() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectionHandleRejectsUnavailableFrames(t *testing.T) {
+	tests := []struct {
+		name    string
+		pt      jt1078.PTType
+		prepare func(*connection)
+		want    error
+	}{
+		{
+			name: "audio",
+			pt:   jt1078.PTAAC,
+			prepare: func(c *connection) {
+				c.publisher.PubAudio = true
+				c.audioWriter = &m7s.PublishAudioWriter[*format.Mpeg2Audio]{Publisher: c.publisher}
+				c.audioWriterOnce.Do(func() {})
+			},
+			want: errAudioFrameUnavailable,
+		},
+		{
+			name: "video",
+			pt:   jt1078.PTH264,
+			prepare: func(c *connection) {
+				c.publisher.PubVideo = true
+				c.videoWriter = &m7s.PublishVideoWriter[*format.AnnexB]{Publisher: c.publisher}
+				c.videoWriterOnce.Do(func() {})
+			},
+			want: errVideoFrameUnavailable,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newTestConnection()
+			c.publisher = &m7s.Publisher{}
+			tt.prepare(c)
+			err := c.handle(&jt1078.Packet{Flag: jt1078.Flag{PT: tt.pt}})
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("handle() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+type panicReadConn struct {
+	net.Conn
+}
+
+func (panicReadConn) Read([]byte) (int, error) {
+	panic("test connection panic")
+}
+
+func (panicReadConn) Close() error {
+	return nil
+}
+
+func TestServiceRunConnectionRecoversPanic(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+	service := &Service{Logger: logger}
+	client := newConnection(panicReadConn{}, logger, func(*jt1078.Packet) time.Duration { return 0 })
+	client.onLeaveEvent = func() {}
+	httpBody := map[string]any{"streamPath": "live/test"}
+
+	service.runConnection(context.Background(), client, 0, &httpBody)
+
+	select {
+	case <-client.stopChan:
+	default:
+		t.Fatal("connection was not stopped after panic")
+	}
+	logOutput := output.String()
+	for _, want := range []string{"connection panic", "test connection panic", "runtime/debug.Stack", "live/test"} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("panic log %q does not contain %q", logOutput, want)
+		}
+	}
+}

--- a/v5/pkg/service.go
+++ b/v5/pkg/service.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 )
@@ -33,6 +34,22 @@ type Service struct {
 	*slog.Logger
 	addr string
 	opts *Options
+}
+
+func (s *Service) runConnection(ctx context.Context, client *connection, waitSubscriberOverTime time.Duration, httpBody *map[string]any) {
+	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			s.Error("connection panic",
+				slog.Any("http body", *httpBody),
+				slog.Any("panic", panicValue),
+				slog.String("stack", string(debug.Stack())))
+		}
+	}()
+	if err := client.run(ctx, waitSubscriberOverTime); err != nil {
+		s.Warn("run error",
+			slog.Any("http body", *httpBody),
+			slog.String("err", err.Error()))
+	}
 }
 
 func (s *Service) Run() {
@@ -99,12 +116,6 @@ func (s *Service) Run() {
 			}
 			cancel()
 		}
-		go func(ctx context.Context, waitSubscriberOverTime time.Duration) {
-			if err := client.run(ctx, waitSubscriberOverTime); err != nil {
-				s.Warn("run error",
-					slog.Any("http body", httpBody),
-					slog.String("err", err.Error()))
-			}
-		}(ctx, s.opts.overTime)
+		go s.runConnection(ctx, client, s.opts.overTime, &httpBody)
 	}
 }


### PR DESCRIPTION
## Summary

- validate the publisher, writer, and current frame before both audio and video writes
- return a connection-scoped error when Monibuca no longer provides a writer/frame instead of dereferencing nil
- recover unexpected panics at the per-connection goroutine boundary and log the full stack
- add regression tests for unavailable publishers, audio/video writers, audio/video frames, cleanup, and panic isolation

## Root cause

In the production crash reported in #9, `connection.handle+0x26a` maps to the Linux/amd64 instruction that reads offset `0x50` from `writer.VideoFrame`. The signal address was also `0x50`, confirming that the frame itself was nil.

After a Monibuca `video timeout`, `Publisher.NoVideo()` sets `PubVideo=false`. A later successful `NextVideo()` calls `getVideoFrameToWrite()`, which returns nil while video publishing is disabled. The next late JT1078 packet then dereferences `frame.Timestamp`. The audio path uses the same unchecked writer/frame pattern.

The existing connection goroutine had no recovery boundary, so this one connection panic terminated the whole gateway process.

## Verification

- `GOTOOLCHAIN=go1.24.0 go test ./... -count=1`
- `go vet ./...`
- `go test -race ./pkg -run "Test(ConnectionHandle|ServiceRunConnection)" -count=1`
- Linux/amd64 cross-compile of the package test binary
- `git diff --check`

A full `go test -race ./pkg` still reports a pre-existing race in `pkg/http_test.go`: its HTTP handler writes to the global `bytes.Buffer` while the test reads/resets it. The new regression tests pass under the race detector.

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of unavailable publishers, writers, and media frames to prevent invalid packet processing.
  * Added recovery for unexpected connection-processing panics, with diagnostic logging to support troubleshooting.
* **Tests**
  * Added coverage for unavailable media resources and panic recovery during connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->